### PR TITLE
Remove admin max-width to use default wrap

### DIFF
--- a/assets/css/admin-pro.css
+++ b/assets/css/admin-pro.css
@@ -1,9 +1,5 @@
 /* Readinizer Pro Admin Styles */
 
-.readinizer-pro-admin .wrap {
-    max-width: 1400px;
-}
-
 .readinizer-pro-header {
     display: flex;
     justify-content: space-between;


### PR DESCRIPTION
## Summary
- remove custom max-width from admin `.wrap` so screens use WordPress default width

## Testing
- `npm test` *(fails: Could not read package.json)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6892874a94188333ad01653ce3c4d4d9