### PR TITLE
Move preview to sidebar and keep it updating

### DIFF
--- a/assets/js/admin-pro.js
+++ b/assets/js/admin-pro.js
@@ -81,15 +81,6 @@
 
     function initTabContent(tab) {
         switch(tab) {
-            case 'general':
-                updatePreview();
-                break;
-            case 'display':
-                updatePreview();
-                break;
-            case 'style':
-                updatePreview();
-                break;
             case 'analytics':
                 if (typeof Chart !== 'undefined') {
                     setTimeout(initializeAnalytics, 100);
@@ -102,17 +93,11 @@
                 initProgressBarPreview();
                 break;
         }
+
+        updatePreview();
     }
 
     function setupFormHandlers() {
-        // Handle all form submissions with AJAX-like preview updates
-        $(document).on('change', 'input, select, textarea', function() {
-            const $form = $(this).closest('form');
-            if ($form.length && $form.find('#readinizer-preview').length) {
-                updatePreview();
-            }
-        });
-
         // Form validation
         $('form').on('submit', function(e) {
             const errors = validateForm($(this));
@@ -127,7 +112,7 @@
 
     function setupPreviewUpdates() {
         // Update preview on any form change
-        $(document).on('change keyup', '#tab-general input, #tab-general select, #tab-display input, #tab-display select, #tab-style input, #tab-style select', debounce(updatePreview, 300));
+        $(document).on('change keyup', '.tab-content input, .tab-content select, .tab-content textarea', debounce(updatePreview, 300));
 
         // Color picker specific handling
         $(document).on('change', '.wp-color-picker', updatePreview);

--- a/readinizer-pro.php
+++ b/readinizer-pro.php
@@ -839,21 +839,7 @@ class ReadinizerPro {
 								</tr>
 							</table>
 
-							<!-- Live Preview Section -->
-							<div class="preview-section">
-								<h3><?php esc_html_e( 'Live Preview', 'readinizer-pro' ); ?></h3>
-								<div id="readinizer-preview" class="preview-box">
-									<?php
-									$sample_stats = array(
-										'reading_time' => 3,
-										'word_count'   => 650,
-									);
-									echo $this->generate_reading_time_html( $sample_stats ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-									?>
-								</div>
-							</div>
-
-							<?php submit_button( __( 'Save Settings', 'readinizer-pro' ) ); ?>
+        <?php submit_button( __( 'Save Settings', 'readinizer-pro' ) ); ?>
 						</form>
 					</div>
 
@@ -1025,7 +1011,21 @@ class ReadinizerPro {
 						</a>
 					</div>
 
-					<div class="readinizer-pro-box">
+                                        <!-- Live Preview Section -->
+                                        <div class="preview-section">
+                                                <h3><?php esc_html_e( 'Live Preview', 'readinizer-pro' ); ?></h3>
+                                                <div id="readinizer-preview" class="preview-box">
+                                                        <?php
+                                                        $sample_stats = array(
+                                                                'reading_time' => 3,
+                                                                'word_count'   => 650,
+                                                        );
+                                                        echo $this->generate_reading_time_html( $sample_stats ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+                                                        ?>
+                                                </div>
+                                        </div>
+
+                                        <div class="readinizer-pro-box">
 						<h3>📖 <?php esc_html_e( 'How to Use', 'readinizer-pro' ); ?></h3>
 						<ul>
 							<li><?php esc_html_e( 'Enable automatic display in General Settings', 'readinizer-pro' ); ?></li>


### PR DESCRIPTION
## Summary
- Relocate Live Preview from the General tab into the sidebar for constant visibility.
- Simplify admin script so the preview refreshes from any settings tab.

## Testing
- `php -l readinizer-pro.php`
- `node --check assets/js/admin-pro.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6892892d63d4833382806e70ec13d259